### PR TITLE
fix bugs uploading category image

### DIFF
--- a/publisher/admin/category.php
+++ b/publisher/admin/category.php
@@ -82,8 +82,8 @@ switch ($op) {
                 $max_imgwidth      = $publisher->getConfig('maximum_image_width');
                 $max_imgheight     = $publisher->getConfig('maximum_image_height');
                 $allowed_mimetypes = publisherGetAllowedImagesTypes();
-                $temp3             = XoopsRequest::getArray('filename', array(), 'FILES');
-                if (!is_readable($tmp_name) || !($tmp_name = $temp3['tmp_name'])) {
+                // $temp3             = XoopsRequest::getArray('filename', array(), 'FILES');
+                if (!is_readable($temp['tmp_name']) || ($temp['tmp_name'] == '')) {
                     redirect_header('javascript:history.go(-1)', 2, _AM_PUBLISHER_FILEUPLOAD_ERROR);
                     //                    exit();
                 }

--- a/publisher/include/onupdate.php
+++ b/publisher/include/onupdate.php
@@ -69,8 +69,24 @@ function xoops_module_update_publisher(XoopsModule $module, $oldversion = null)
         //       $folderHandler   = XoopsFile::getHandler('file', $cssFile);
         //       $folderHandler->delete($cssFile);
     }
+    
+    // Checking/Making of "uploads" folders
+    $indexFile = $GLOBALS['xoops']->path('uploads/index.html');
+    $dirUpload = $GLOBALS['xoops']->path('uploads/' . $module->getVar('dirname', 'n') . '/images/');
+    if(!is_dir($dirUpload)) {
+      mkdir($dirUpload, 0777);
+      chmod($dirUpload, 0777);
+      copy($indexFile, $dirUpload.'/index.html');
+    }
+    $dirUpload = $GLOBALS['xoops']->path('uploads/' . $module->getVar('dirname', 'n') . '/images/category/');
+    if(!is_dir($dirUpload)) {
+      mkdir($dirUpload, 0777);
+      chmod($dirUpload, 0777);
+      copy($indexFile, $dirUpload.'/index.html');
+    }
 
     $gpermHandler =& xoops_getHandler('groupperm');
-
+    
     return $gpermHandler->deleteByModule($module->getVar('mid'), 'item_read');
+
 }


### PR DESCRIPTION
missing upload directory for category images:
uploads/publisher/images/category/
changed include/onupdate.php

error when uploading category image
admin/category.php:
REM line 85
line 86: replaced [quote] if (!is_readable($tmp_name) || !($tmp_name =
$temp3['tmp_name'])) {[/quote] by [quote]if
(!is_readable($temp['tmp_name']) || ($temp['tmp_name'] == '')) {[/quote]