### PR TITLE
Fix Ratings when SEO is set to path-info

### DIFF
--- a/extra/seo/sample.htaccess
+++ b/extra/seo/sample.htaccess
@@ -1,7 +1,8 @@
 RewriteEngine   On
 
-#For Ajax Rating
-RewriteRule ^publisher\.([a-z]+)\.([0-9.]+)\/include\/ajax_rating\.php$ modules/publisher/include/ajax_rating.php/?%{QUERY_STRING}
+#For Ajax Rating -
+RewriteRule ^modules\/publisher\/index\.php\/([a-z]+)\.([0-9.]+)\/include\/ajax_rating\.php$ modules/publisher/include/ajax_rating.php?%{QUERY_STRING}
+RewriteRule ^publisher\.([a-z]+)\.([0-9.]+)\/include\/ajax_rating\.php$ modules/publisher/include/ajax_rating.php?%{QUERY_STRING}
 
 #SEO .Htaccess setting
 RewriteRule ^publisher\.([a-z]+)\.([0-9.]+)/  modules/publisher/index.php?seoOp=$1&seoArg=$2


### PR DESCRIPTION
I forgot to also test the other SEO option. This should fix the AJAX Ratings using SEO path-info.