### PR TITLE
Fix issue with Admin Category page being blank

### DIFF
--- a/class/CategoryHandler.php
+++ b/class/CategoryHandler.php
@@ -199,17 +199,19 @@ class CategoryHandler extends \XoopsPersistableObjectHandler
             $criteria->add(new \Criteria('parentid', (int)$parentid));
         }
         if (!$this->publisherIsAdmin) {
+            $criteria2 = new \CriteriaCompo();
             /** @var PermissionHandler $permissionHandler */
             $permissionHandler = $this->helper->getHandler('Permission');
             $categoriesGranted = $permissionHandler->getGrantedItems('category_read');
             if (\count($categoriesGranted) > 0) {
-                $criteria->add(new \Criteria('categoryid', '(' . \implode(',', $categoriesGranted) . ')', 'IN'));
+                $criteria2->add(new \Criteria('categoryid', '(' . \implode(',', $categoriesGranted) . ')', 'IN'));
             } else {
                 return $ret;
             }
             if (\is_object($GLOBALS['xoopsUser'])) {
-                $criteria->add(new \Criteria('moderator', $GLOBALS['xoopsUser']->getVar('uid')), 'OR');
+                $criteria2->add(new \Criteria('moderator', $GLOBALS['xoopsUser']->getVar('uid')), 'OR');
             }
+            $criteria->add($criteria2);
         }
         $criteria->setStart($start);
         $criteria->setLimit($limit);

--- a/class/Utility.php
+++ b/class/Utility.php
@@ -176,7 +176,7 @@ class Utility extends Common\SysUtility
         $helper = Helper::getInstance();
 
         $description = $categoryObj->description();
-        if (!XOOPS_USE_MULTIBYTES) {
+        if (!XOOPS_USE_MULTIBYTES and !is_null($description)) {
             if (mb_strlen($description) >= 100) {
                 $description = mb_substr($description, 0, 100 - 1) . '...';
             }


### PR DESCRIPTION
Fix issue with admin category page where selecting a moderator will create an infinite loop. Also fixed an issue with a null Category Description being sent to mb_strlen.

Fixes #151 