### PR TITLE
Fix issue with strings being sent to chr()

### DIFF
--- a/class/Metagen.php
+++ b/class/Metagen.php
@@ -436,7 +436,7 @@ class Metagen
         \preg_replace_callback(
             '/&#(\d+);/',
             static function ($matches) {
-                return \chr($matches[1]);
+                return \chr(intval($matches[1]));
             },
             $document
         );

--- a/class/Utility.php
+++ b/class/Utility.php
@@ -522,7 +522,7 @@ class Utility extends Common\SysUtility
         \preg_replace_callback(
             '/&#(\d+);/',
             static function ($matches) {
-                return \chr($matches[1]);
+                return \chr(intval($matches[1]));
             },
             $document
         );


### PR DESCRIPTION
Fix for "Erreur : TypeError : chr() : l'argument #1 ($codepoint) doit être de type int, chaîne donnée"

Reported by: ON2AT

https://www.frxoops.org/modules/newbb/viewtopic.php?viewmode=flat&type=&topic_id=38396&forum=12 