### PR TITLE
Fix: uid is lost when user edit own article

### DIFF
--- a/class/Item.php
+++ b/class/Item.php
@@ -1157,7 +1157,12 @@ class Item extends \XoopsObject
             $this->setVar('dobr', $this->helper->getConfig('submit_dobr'));
             $this->setVar('votetype', $this->helper->getConfig('ratingbars'));
         } else {
-            $this->setVar('uid', Request::getInt('uid', 0, 'POST'));
+            $author_uid = Request::getInt('uid', 0, 'POST');
+            if(!$author_uid) {
+              $author_uid = is_object($GLOBALS['xoopsUser']) ? $GLOBALS['xoopsUser']->uid() : 0;
+            }
+
+            $this->setVar('uid', $author_uid);
             $this->setVar('cancomment', Request::getInt('allowcomments', 1, 'POST'));
             $this->setVar('status', Request::getInt('status', 1, 'POST'));
             $this->setVar('dohtml', Request::getInt('dohtml', 1, 'POST'));


### PR DESCRIPTION
This is a fix for the situation where the Users' editing their articles is enabled but the "Poster name" field is not available. In this situation, the form doesn't have the uid, and when the users edit their articles, the author uid changes to zero, which is the anonymous.

As you can understand, having the "Poster name" field available to the non-admins users is a problem, which is fixed by this PR.